### PR TITLE
Use `ldh [$FF00+c]`, not `ld [$FF00+c]`

### DIFF
--- a/src/fade.z80
+++ b/src/fade.z80
@@ -263,7 +263,7 @@ section "gbcfadecode", ROM0
 ; @param HL data source
 ; @return HL at end, C increased by 1, B = 0
 set_gbc_palette_hblank:
-  ld [$FF00+c],a
+  ldh [$FF00+c],a
   inc c
 
   ; catch all VRAM slots
@@ -288,10 +288,10 @@ set_gbc_palette_hblank:
   nop
   ; At worst, we get 85 dots of mode 0 plus 80 dots of mode 2
   ; on next line, for 165 dots or 41 cycles. We'll use 30.
-  ld [$FF00+c], a
+  ldh [$FF00+c], a
     rept 7
     ld a, [hl+]
-    ld [$FF00+c], a
+    ldh [$FF00+c], a
   endr
   dec b
   jr nz, .palblastloop

--- a/src/ppuclear.z80
+++ b/src/ppuclear.z80
@@ -218,7 +218,7 @@ set_gbc_mono_palette::
   rlca
   ld e,a
   ld a,b  ; Regmap now: E=BGP<<1, A=palette offset, C=address port
-  ld [$FF00+c],a
+  ldh [$FF00+c],a
   inc c   ; C=data port
   rra  ; Count remaining colors
   or %11111100
@@ -233,9 +233,9 @@ set_gbc_mono_palette::
     or low(gbmonopalette)
     ld l,a  ; now L points to this color so stuff it into the palette
     ld a,[hl+]
-    ld [$FF00+c],a
+    ldh [$FF00+c],a
     ld a,[hl-]
-    ld [$FF00+c],a
+    ldh [$FF00+c],a
     ld a, e  ; move to next bitfield of BGP
     rrca
     rrca
@@ -255,11 +255,11 @@ set_gbc_mono_palette::
 ; @param HL data source
 ; @return HL at end, C increased by 1, B = 0, DE unchanged
 set_gbc_palette::
-  ld [$FF00+c],a
+  ldh [$FF00+c],a
   inc c
   .loop:
     ld a,[hl+]
-    ld [$FF00+c],a
+    ldh [$FF00+c],a
     dec b
     jr nz,.loop
   ret


### PR DESCRIPTION
RGBDS 0.9.0 [deprecates](https://rgbds.gbdev.io/docs/master/rgbasm-old.5#LD__C_,_A_and_LD_A,__C_) `ld [$FF00+c]`.